### PR TITLE
(GH-16) Allow to limit maximum issues per issue provider

### DIFF
--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -366,9 +366,26 @@
             }
 
             [Fact]
-            public void Should_Limit_Messages_To_Maximum()
+            public void Should_Limit_Messages_To_Global_Maximum()
             {
                 // Given
+                var issue1 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        10,
+                        "Foo",
+                        0,
+                        "Foo",
+                        "Foo");
+                var issue2 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        12,
+                        "Bar",
+                        1,
+                        "Bar",
+                        "Bar");
+
                 var fixture = new PullRequestsFixture();
                 fixture.IssueProviders.Clear();
                 fixture.IssueProviders.Add(
@@ -376,20 +393,7 @@
                         fixture.Log,
                         new List<IIssue>
                         {
-                            new Issue(
-                                @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
-                                10,
-                                "Foo",
-                                0,
-                                "Foo",
-                                "Foo"),
-                            new Issue(
-                                @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
-                                12,
-                                "Bar",
-                                0,
-                                "Bar",
-                                "Bar")
+                            issue1, issue2
                         }));
 
                 fixture.PullRequestSystem =
@@ -404,11 +408,84 @@
                 fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPost = 1;
 
                 // When
-                fixture.RunOrchestrator();
+                var result = fixture.RunOrchestrator();
 
                 // Then
-                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the maximum 1 comments limit");
+                result.ReportedIssues.Count().ShouldBe(2);
+                result.PostedIssues.Count().ShouldBe(1);
+                result.PostedIssues.ShouldContain(issue2);
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 1");
                 fixture.Log.Entries.ShouldContain(x => x.Message.StartsWith("Posting 1 issue(s):"));
+            }
+
+            [Fact]
+            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider()
+            {
+                // Given
+                var issue1 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        10,
+                        "Foo",
+                        0,
+                        "Foo",
+                        "ProviderA");
+                var issue2 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        12,
+                        "Foo",
+                        1,
+                        "Foo",
+                        "ProviderA");
+                var issue3 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        10,
+                        "Bar",
+                        1,
+                        "Bar",
+                        "ProviderB");
+                var issue4 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        12,
+                        "Bar",
+                        0,
+                        "Bar",
+                        "ProviderB");
+                var fixture = new PullRequestsFixture();
+                fixture.IssueProviders.Clear();
+                fixture.IssueProviders.Add(
+                    new FakeIssueProvider(
+                        fixture.Log,
+                        new List<IIssue>
+                        {
+                            issue1, issue2, issue3, issue4
+                        }));
+
+                fixture.PullRequestSystem =
+                    new FakePullRequestSystem(
+                        fixture.Log,
+                        new List<IPullRequestDiscussionThread>(),
+                        new List<FilePath>
+                        {
+                            new FilePath(@"src\Cake.Issues.Tests\FakeIssueProvider.cs")
+                        });
+
+                fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPostForEachIssueProvider = 1;
+
+                // When
+                var result = fixture.RunOrchestrator();
+
+                // Then
+                result.ReportedIssues.Count().ShouldBe(4);
+                result.PostedIssues.Count().ShouldBe(2);
+                result.PostedIssues.ShouldContain(issue2);
+                result.PostedIssues.ShouldContain(issue3);
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) of type ProviderA were filtered to match the maximum of 1 issues which should be reported for each issue provider");
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) of type ProviderB were filtered to match the maximum of 1 issues which should be reported for each issue provider");
+                fixture.Log.Entries.ShouldContain(x => x.Message.StartsWith("Posting 2 issue(s):"));
             }
 
             [Fact]

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -382,7 +382,113 @@
                         @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
                         12,
                         "Bar",
+                        0,
+                        "Bar",
+                        "Bar");
+
+                var fixture = new PullRequestsFixture();
+                fixture.IssueProviders.Clear();
+                fixture.IssueProviders.Add(
+                    new FakeIssueProvider(
+                        fixture.Log,
+                        new List<IIssue>
+                        {
+                            issue1, issue2
+                        }));
+
+                fixture.PullRequestSystem =
+                    new FakePullRequestSystem(
+                        fixture.Log,
+                        new List<IPullRequestDiscussionThread>(),
+                        new List<FilePath>
+                        {
+                            new FilePath(@"src\Cake.Issues.Tests\FakeIssueProvider.cs")
+                        });
+
+                fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPost = 1;
+
+                // When
+                var result = fixture.RunOrchestrator();
+
+                // Then
+                result.ReportedIssues.Count().ShouldBe(2);
+                result.PostedIssues.Count().ShouldBe(1);
+                result.PostedIssues.ShouldContain(issue1);
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 1");
+                fixture.Log.Entries.ShouldContain(x => x.Message.StartsWith("Posting 1 issue(s):"));
+            }
+
+            [Fact]
+            public void Should_Limit_Messages_To_Global_Maximum_By_Priority()
+            {
+                // Given
+                var issue1 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        10,
+                        "Foo",
+                        0,
+                        "Foo",
+                        "Foo");
+                var issue2 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        12,
+                        "Bar",
                         1,
+                        "Bar",
+                        "Bar");
+
+                var fixture = new PullRequestsFixture();
+                fixture.IssueProviders.Clear();
+                fixture.IssueProviders.Add(
+                    new FakeIssueProvider(
+                        fixture.Log,
+                        new List<IIssue>
+                        {
+                            issue1, issue2
+                        }));
+
+                fixture.PullRequestSystem =
+                    new FakePullRequestSystem(
+                        fixture.Log,
+                        new List<IPullRequestDiscussionThread>(),
+                        new List<FilePath>
+                        {
+                            new FilePath(@"src\Cake.Issues.Tests\FakeIssueProvider.cs")
+                        });
+
+                fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPost = 1;
+
+                // When
+                var result = fixture.RunOrchestrator();
+
+                // Then
+                result.ReportedIssues.Count().ShouldBe(2);
+                result.PostedIssues.Count().ShouldBe(1);
+                result.PostedIssues.ShouldContain(issue2);
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 1");
+                fixture.Log.Entries.ShouldContain(x => x.Message.StartsWith("Posting 1 issue(s):"));
+            }
+
+            [Fact]
+            public void Should_Limit_Messages_To_Global_Maximum_By_FilePath()
+            {
+                // Given
+                var issue1 =
+                    new Issue(
+                        null,
+                        null,
+                        "Foo",
+                        0,
+                        "Foo",
+                        "Foo");
+                var issue2 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        12,
+                        "Bar",
+                        0,
                         "Bar",
                         "Bar");
 
@@ -435,6 +541,76 @@
                         @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
                         12,
                         "Foo",
+                        0,
+                        "Foo",
+                        "ProviderA");
+                var issue3 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        10,
+                        "Bar",
+                        0,
+                        "Bar",
+                        "ProviderB");
+                var issue4 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        12,
+                        "Bar",
+                        0,
+                        "Bar",
+                        "ProviderB");
+                var fixture = new PullRequestsFixture();
+                fixture.IssueProviders.Clear();
+                fixture.IssueProviders.Add(
+                    new FakeIssueProvider(
+                        fixture.Log,
+                        new List<IIssue>
+                        {
+                            issue1, issue2, issue3, issue4
+                        }));
+
+                fixture.PullRequestSystem =
+                    new FakePullRequestSystem(
+                        fixture.Log,
+                        new List<IPullRequestDiscussionThread>(),
+                        new List<FilePath>
+                        {
+                            new FilePath(@"src\Cake.Issues.Tests\FakeIssueProvider.cs")
+                        });
+
+                fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPostForEachIssueProvider = 1;
+
+                // When
+                var result = fixture.RunOrchestrator();
+
+                // Then
+                result.ReportedIssues.Count().ShouldBe(4);
+                result.PostedIssues.Count().ShouldBe(2);
+                result.PostedIssues.ShouldContain(issue1);
+                result.PostedIssues.ShouldContain(issue3);
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) of type ProviderA were filtered to match the maximum of 1 issues which should be reported for each issue provider");
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) of type ProviderB were filtered to match the maximum of 1 issues which should be reported for each issue provider");
+                fixture.Log.Entries.ShouldContain(x => x.Message.StartsWith("Posting 2 issue(s):"));
+            }
+
+            [Fact]
+            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_By_Priority()
+            {
+                // Given
+                var issue1 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        10,
+                        "Foo",
+                        0,
+                        "Foo",
+                        "ProviderA");
+                var issue2 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        12,
+                        "Foo",
                         1,
                         "Foo",
                         "ProviderA");
@@ -450,6 +626,76 @@
                     new Issue(
                         @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
                         12,
+                        "Bar",
+                        0,
+                        "Bar",
+                        "ProviderB");
+                var fixture = new PullRequestsFixture();
+                fixture.IssueProviders.Clear();
+                fixture.IssueProviders.Add(
+                    new FakeIssueProvider(
+                        fixture.Log,
+                        new List<IIssue>
+                        {
+                            issue1, issue2, issue3, issue4
+                        }));
+
+                fixture.PullRequestSystem =
+                    new FakePullRequestSystem(
+                        fixture.Log,
+                        new List<IPullRequestDiscussionThread>(),
+                        new List<FilePath>
+                        {
+                            new FilePath(@"src\Cake.Issues.Tests\FakeIssueProvider.cs")
+                        });
+
+                fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPostForEachIssueProvider = 1;
+
+                // When
+                var result = fixture.RunOrchestrator();
+
+                // Then
+                result.ReportedIssues.Count().ShouldBe(4);
+                result.PostedIssues.Count().ShouldBe(2);
+                result.PostedIssues.ShouldContain(issue2);
+                result.PostedIssues.ShouldContain(issue3);
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) of type ProviderA were filtered to match the maximum of 1 issues which should be reported for each issue provider");
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) of type ProviderB were filtered to match the maximum of 1 issues which should be reported for each issue provider");
+                fixture.Log.Entries.ShouldContain(x => x.Message.StartsWith("Posting 2 issue(s):"));
+            }
+
+            [Fact]
+            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_By_FilePath()
+            {
+                // Given
+                var issue1 =
+                    new Issue(
+                        null,
+                        null,
+                        "Foo",
+                        0,
+                        "Foo",
+                        "ProviderA");
+                var issue2 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        12,
+                        "Foo",
+                        0,
+                        "Foo",
+                        "ProviderA");
+                var issue3 =
+                    new Issue(
+                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                        10,
+                        "Bar",
+                        0,
+                        "Bar",
+                        "ProviderB");
+                var issue4 =
+                    new Issue(
+                        null,
+                        null,
                         "Bar",
                         0,
                         "Bar",

--- a/src/Cake.Issues.PullRequests/IssueFilterer.cs
+++ b/src/Cake.Issues.PullRequests/IssueFilterer.cs
@@ -184,6 +184,8 @@
                     var issuesFiltered =
                         group
                             .OrderByDescending(x => x.Priority)
+                            .ThenBy(x => x.AffectedFileRelativePath is null)
+                            .ThenBy(x => x.AffectedFileRelativePath?.FullPath)
                             .Take(this.settings.MaxIssuesToPostForEachIssueProvider.Value);
 
                     this.log.Information(
@@ -203,6 +205,8 @@
                 result =
                     result
                         .OrderByDescending(x => x.Priority)
+                        .ThenBy(x => x.AffectedFileRelativePath is null)
+                        .ThenBy(x => x.AffectedFileRelativePath?.FullPath)
                         .Take(this.settings.MaxIssuesToPost.Value)
                         .ToList();
                 var commentsFiltered = countBefore - result.Count;

--- a/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestSettings.cs
+++ b/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestSettings.cs
@@ -27,6 +27,8 @@
         /// <summary>
         /// Gets or sets the global number of issues which should be posted at maximum over all
         /// <see cref="IIssueProvider"/>.
+        /// Issues are filtered by <see cref="IIssue.Priority"/> and issues with an <see cref="IIssue.AffectedFileRelativePath"/>
+        /// are prioritized.
         /// Set to <see langword="null"/> to not set a global limit.
         /// Default is to not set a global limit.
         /// Use <see cref="MaxIssuesToPostForEachIssueProvider"/> to set the limit for each issue provider.
@@ -36,6 +38,8 @@
         /// <summary>
         /// Gets or sets the global number of issues which should be posted at for each
         /// <see cref="IIssueProvider"/>.
+        /// Issues are filtered by <see cref="IIssue.Priority"/> and issues with an <see cref="IIssue.AffectedFileRelativePath"/>
+        /// are prioritized.
         /// Set to <see langword="null"/> to not limit issues per issue provider.
         /// Default is to filter to 100 issues for each issue provider.
         /// Use <see cref="MaxIssuesToPost"/> to set the global limit over all issue providers.

--- a/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestSettings.cs
+++ b/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestSettings.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests
 {
+    using System.Collections.Generic;
     using Core.IO;
 
     /// <summary>
@@ -7,6 +8,8 @@
     /// </summary>
     public class ReportIssuesToPullRequestSettings : RepositorySettings
     {
+        private readonly Dictionary<IIssueProvider, int> maxIssuesToPost = new Dictionary<IIssueProvider, int>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ReportIssuesToPullRequestSettings"/> class.
         /// </summary>
@@ -22,9 +25,22 @@
         public string CommitId { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of issues which should be posted at maximum.
+        /// Gets or sets the global number of issues which should be posted at maximum over all
+        /// <see cref="IIssueProvider"/>.
+        /// Set to <see langword="null"/> to not set a global limit.
+        /// Default is to not set a global limit.
+        /// Use <see cref="MaxIssuesToPostForEachIssueProvider"/> to set the limit for each issue provider.
         /// </summary>
-        public int MaxIssuesToPost { get; set; } = 100;
+        public int? MaxIssuesToPost { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the global number of issues which should be posted at for each
+        /// <see cref="IIssueProvider"/>.
+        /// Set to <see langword="null"/> to not limit issues per issue provider.
+        /// Default is to filter to 100 issues for each issue provider.
+        /// Use <see cref="MaxIssuesToPost"/> to set the global limit over all issue providers.
+        /// </summary>
+        public int? MaxIssuesToPostForEachIssueProvider { get; set; } = 100;
 
         /// <summary>
         /// Gets or sets a value used to decorate comments created by this addin.


### PR DESCRIPTION
Adds a new `MaxIssuesToPostForEachIssueProvider` setting. Defaults have changed to limit to 100 issues per issue provider instead of global.

Also changed filter logic to prioritize issues affecting a file over issues without a file path.

Fixes #16 