### PR TITLE
(GH-29) (GH-30) Support different resolutions for comment thread resolving

### DIFF
--- a/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystem.cs
@@ -107,7 +107,7 @@
         }
 
         /// <inheritdoc />
-        protected override IEnumerable<IPullRequestDiscussionThread> InternalFetchActiveDiscussionThreads(string commentSource)
+        protected override IEnumerable<IPullRequestDiscussionThread> InternalFetchDiscussionThreads(string commentSource)
         {
             return this.discussionThreads;
         }

--- a/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystem.cs
@@ -11,7 +11,8 @@
     {
         private readonly List<IPullRequestDiscussionThread> discussionThreads = new List<IPullRequestDiscussionThread>();
         private readonly List<FilePath> modifiedFiles = new List<FilePath>();
-        private readonly List<IPullRequestDiscussionThread> threadsMarkedAsFixed = new List<IPullRequestDiscussionThread>();
+        private readonly List<IPullRequestDiscussionThread> resolvedThreads = new List<IPullRequestDiscussionThread>();
+        private readonly List<IPullRequestDiscussionThread> reopenedThreads = new List<IPullRequestDiscussionThread>();
         private readonly List<IIssue> postedIssues = new List<IIssue>();
 
         /// <summary>
@@ -64,7 +65,12 @@
         /// <summary>
         /// Gets the discussion threads marked as fixed.
         /// </summary>
-        public IEnumerable<IPullRequestDiscussionThread> ThreadsMarkedAsFixed => this.threadsMarkedAsFixed;
+        public IEnumerable<IPullRequestDiscussionThread> ResolvedThreads => this.resolvedThreads;
+
+        /// <summary>
+        /// Gets the discussion threads marked as active.
+        /// </summary>
+        public IEnumerable<IPullRequestDiscussionThread> ReopenedThreads => this.reopenedThreads;
 
         /// <summary>
         /// Gets the issues posted to the pull request.
@@ -119,13 +125,23 @@
         }
 
         /// <inheritdoc />
-        protected override void InternalMarkThreadsAsFixed(IEnumerable<IPullRequestDiscussionThread> threads)
+        protected override void InternalResolveDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             threads.NotNull(nameof(threads));
 
             // ReSharper disable once PossibleMultipleEnumeration
-            this.threadsMarkedAsFixed.AddRange(threads);
+            this.resolvedThreads.AddRange(threads);
+        }
+
+        /// <inheritdoc />
+        protected override void InternalReopenDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads)
+        {
+            // ReSharper disable once PossibleMultipleEnumeration
+            threads.NotNull(nameof(threads));
+
+            // ReSharper disable once PossibleMultipleEnumeration
+            this.reopenedThreads.AddRange(threads);
         }
 
         /// <inheritdoc />

--- a/src/Cake.Issues.PullRequests.Tests/PullRequestSystemTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/PullRequestSystemTests.cs
@@ -59,7 +59,7 @@
                 var prSystem = new FakePullRequestSystem(new FakeLog());
 
                 // When
-                var result = Record.Exception(() => prSystem.FetchActiveDiscussionThreads("Foo"));
+                var result = Record.Exception(() => prSystem.FetchDiscussionThreads("Foo"));
 
                 // Then
                 result.IsInvalidOperationException("Initialize needs to be called first.");

--- a/src/Cake.Issues.PullRequests.Tests/PullRequestSystemTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/PullRequestSystemTests.cs
@@ -91,7 +91,7 @@
                 var prSystem = new FakePullRequestSystem(new FakeLog());
 
                 // When
-                var result = Record.Exception(() => prSystem.MarkThreadsAsFixed(new List<IPullRequestDiscussionThread>()));
+                var result = Record.Exception(() => prSystem.ResolveDiscussionThreads(new List<IPullRequestDiscussionThread>()));
 
                 // Then
                 result.IsInvalidOperationException("Initialize needs to be called first.");

--- a/src/Cake.Issues.PullRequests.Tests/PullRequestsFixture.cs
+++ b/src/Cake.Issues.PullRequests.Tests/PullRequestsFixture.cs
@@ -41,7 +41,7 @@
 
         public IEnumerable<IIssue> FilterIssues(
             IEnumerable<IIssue> issues,
-            IDictionary<IIssue, IEnumerable<IPullRequestDiscussionComment>> issueComments)
+            IDictionary<IIssue, IssueCommentInfo> issueComments)
         {
             this.PullRequestSystem?.Initialize(this.ReportIssuesToPullRequestSettings);
 

--- a/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
+++ b/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.PullRequests.xml</DocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.PullRequests.xml</DocumentationFile>

--- a/src/Cake.Issues.PullRequests/IPullRequestDiscussionThread.cs
+++ b/src/Cake.Issues.PullRequests/IPullRequestDiscussionThread.cs
@@ -19,6 +19,11 @@
         PullRequestDiscussionStatus Status { get; set; }
 
         /// <summary>
+        /// Gets or sets the resolution of the thred if <see cref="Status"/> is <see cref="PullRequestDiscussionStatus.Resolved"/>.
+        /// </summary>
+        PullRequestDiscussionResolution Resolution { get; set; }
+
+        /// <summary>
         /// Gets or sets the path to the file where the message should be posted.
         /// The path needs to be relative to the repository root.
         /// Can be <c>null</c> if discussion is not related to a change in a file.

--- a/src/Cake.Issues.PullRequests/IPullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests/IPullRequestSystem.cs
@@ -23,11 +23,11 @@
         IssueCommentFormat GetPreferredCommentFormat();
 
         /// <summary>
-        /// Returns a list of all active discussion threads.
+        /// Returns a list of all discussion threads.
         /// </summary>
         /// <param name="commentSource">Value used to indicate threads created by this addin.</param>
-        /// <returns>List of all active discussion threads.</returns>
-        IEnumerable<IPullRequestDiscussionThread> FetchActiveDiscussionThreads(string commentSource);
+        /// <returns>List of all discussion threads.</returns>
+        IEnumerable<IPullRequestDiscussionThread> FetchDiscussionThreads(string commentSource);
 
         /// <summary>
         /// Marks a list of discussion threads as resolved.

--- a/src/Cake.Issues.PullRequests/IPullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests/IPullRequestSystem.cs
@@ -33,7 +33,13 @@
         /// Marks a list of discussion threads as resolved.
         /// </summary>
         /// <param name="threads">Threads to mark as fixed.</param>
-        void MarkThreadsAsFixed(IEnumerable<IPullRequestDiscussionThread> threads);
+        void ResolveDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads);
+
+        /// <summary>
+        /// Marks a list of discussion threads as active.
+        /// </summary>
+        /// <param name="threads">Threads to mark as active.</param>
+        void ReopenDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads);
 
         /// <summary>
         /// Returns a list of all files modified in a pull request.

--- a/src/Cake.Issues.PullRequests/IssueCommentInfo.cs
+++ b/src/Cake.Issues.PullRequests/IssueCommentInfo.cs
@@ -1,0 +1,46 @@
+﻿namespace Cake.Issues.PullRequests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Information about comments of an issue.
+    /// </summary>
+    internal class IssueCommentInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IssueCommentInfo"/> class.
+        /// </summary>
+        /// <param name="activeComments">Active comments.</param>
+        /// <param name="wontFixComments">Comments from threads marked as won't fix.</param>
+        /// <param name="resolvedComments">Comments from threads marked as resolved.</param>
+        public IssueCommentInfo(
+            IEnumerable<IPullRequestDiscussionComment> activeComments,
+            IEnumerable<IPullRequestDiscussionComment> wontFixComments,
+            IEnumerable<IPullRequestDiscussionComment> resolvedComments)
+        {
+            activeComments.NotNull(nameof(activeComments));
+            wontFixComments.NotNull(nameof(wontFixComments));
+            resolvedComments.NotNull(nameof(resolvedComments));
+
+            this.ActiveComments = activeComments.ToList();
+            this.WontFixComments = wontFixComments.ToList();
+            this.ResolvedComments = resolvedComments.ToList();
+        }
+
+        /// <summary>
+        /// Gets active comments.
+        /// </summary>
+        public IEnumerable<IPullRequestDiscussionComment> ActiveComments { get; }
+
+        /// <summary>
+        /// Gets comments from threads marked as won't fix.
+        /// </summary>
+        public IEnumerable<IPullRequestDiscussionComment> WontFixComments { get; }
+
+        /// <summary>
+        /// Gets comments from threads marked as resolved.
+        /// </summary>
+        public IEnumerable<IPullRequestDiscussionComment> ResolvedComments { get; }
+    }
+}

--- a/src/Cake.Issues.PullRequests/IssueFilterer.cs
+++ b/src/Cake.Issues.PullRequests/IssueFilterer.cs
@@ -44,7 +44,7 @@
         /// <returns>List of filtered issues.</returns>
         public IEnumerable<IIssue> FilterIssues(
             IEnumerable<IIssue> issues,
-            IDictionary<IIssue, IEnumerable<IPullRequestDiscussionComment>> issueComments)
+            IDictionary<IIssue, IssueCommentInfo> issueComments)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull(nameof(issues));
@@ -82,11 +82,14 @@
         /// <returns>True if there are already comments for an issue.</returns>
         private static bool IssueHasMatchingComments(
             IIssue issue,
-            IDictionary<IIssue, IEnumerable<IPullRequestDiscussionComment>> issueComments)
+            IDictionary<IIssue, IssueCommentInfo> issueComments)
         {
             return
                 issueComments.ContainsKey(issue) &&
-                issueComments[issue].Any();
+                (
+                    issueComments[issue].ActiveComments.Any() ||
+                    issueComments[issue].WontFixComments.Any() ||
+                    issueComments[issue].ResolvedComments.Any());
         }
 
         /// <summary>
@@ -151,7 +154,7 @@
         /// <returns>List issues filtered to only the ones not having already a comment.</returns>
         private IList<IIssue> FilterPreExistingComments(
             IList<IIssue> issues,
-            IDictionary<IIssue, IEnumerable<IPullRequestDiscussionComment>> issueComments)
+            IDictionary<IIssue, IssueCommentInfo> issueComments)
         {
             if (!issues.Any())
             {

--- a/src/Cake.Issues.PullRequests/Orchestrator.cs
+++ b/src/Cake.Issues.PullRequests/Orchestrator.cs
@@ -118,7 +118,7 @@
             this.log.Information("Fetching existing threads and comments...");
 
             var existingThreads =
-                this.pullRequestSystem.FetchActiveDiscussionThreads(
+                this.pullRequestSystem.FetchDiscussionThreads(
                     reportIssuesToPullRequestSettings.CommentSource).ToList();
 
             var issueComments =

--- a/src/Cake.Issues.PullRequests/PullRequestDiscussionResolution.cs
+++ b/src/Cake.Issues.PullRequests/PullRequestDiscussionResolution.cs
@@ -1,0 +1,23 @@
+﻿namespace Cake.Issues.PullRequests
+{
+    /// <summary>
+    /// Resolution of discussions in pull requests.
+    /// </summary>
+    public enum PullRequestDiscussionResolution
+    {
+        /// <summary>
+        /// Unknown discussion resolution.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Discussion is resolved.
+        /// </summary>
+        Resolved,
+
+        /// <summary>
+        /// Discussion is marked as won't fix.
+        /// </summary>
+        WontFix
+    }
+}

--- a/src/Cake.Issues.PullRequests/PullRequestDiscussionThread.cs
+++ b/src/Cake.Issues.PullRequests/PullRequestDiscussionThread.cs
@@ -54,6 +54,9 @@
         public PullRequestDiscussionStatus Status { get; set; }
 
         /// <inheritdoc/>
+        public PullRequestDiscussionResolution Resolution { get; set; }
+
+        /// <inheritdoc/>
         public FilePath AffectedFileRelativePath { get; set; }
 
         /// <inheritdoc/>

--- a/src/Cake.Issues.PullRequests/PullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests/PullRequestSystem.cs
@@ -47,11 +47,19 @@
         }
 
         /// <inheritdoc/>
-        public void MarkThreadsAsFixed(IEnumerable<IPullRequestDiscussionThread> threads)
+        public void ResolveDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads)
         {
             this.AssertSettings();
 
-            this.InternalMarkThreadsAsFixed(threads);
+            this.InternalResolveDiscussionThreads(threads);
+        }
+
+        /// <inheritdoc/>
+        public void ReopenDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads)
+        {
+            this.AssertSettings();
+
+            this.InternalReopenDiscussionThreads(threads);
         }
 
         /// <inheritdoc/>
@@ -79,10 +87,17 @@
 
         /// <summary>
         /// Marks a list of discussion threads as resolved.
-        /// Compared to <see cref="MarkThreadsAsFixed"/> it is safe to access Settings from this method.
+        /// Compared to <see cref="ResolveDiscussionThreads"/> it is safe to access Settings from this method.
         /// </summary>
         /// <param name="threads">Threads to mark as fixed.</param>
-        protected abstract void InternalMarkThreadsAsFixed(IEnumerable<IPullRequestDiscussionThread> threads);
+        protected abstract void InternalResolveDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads);
+
+        /// <summary>
+        /// Marks a list of discussion threads as active.
+        /// Compared to <see cref="ReopenDiscussionThreads"/> it is safe to access Settings from this method.
+        /// </summary>
+        /// <param name="threads">Threads to mark as active.</param>
+        protected abstract void InternalReopenDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads);
 
         /// <summary>
         /// Posts discussion threads for all issues which need to be posted.

--- a/src/Cake.Issues.PullRequests/PullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests/PullRequestSystem.cs
@@ -31,11 +31,11 @@
         }
 
         /// <inheritdoc/>
-        public IEnumerable<IPullRequestDiscussionThread> FetchActiveDiscussionThreads(string commentSource)
+        public IEnumerable<IPullRequestDiscussionThread> FetchDiscussionThreads(string commentSource)
         {
             this.AssertSettings();
 
-            return this.InternalFetchActiveDiscussionThreads(commentSource);
+            return this.InternalFetchDiscussionThreads(commentSource);
         }
 
         /// <inheritdoc/>
@@ -63,12 +63,12 @@
         }
 
         /// <summary>
-        /// Returns a list of all active discussion threads.
-        /// Compared to <see cref="FetchActiveDiscussionThreads"/> it is safe to access Settings from this method.
+        /// Returns a list of all discussion threads.
+        /// Compared to <see cref="FetchDiscussionThreads"/> it is safe to access Settings from this method.
         /// </summary>
         /// <param name="commentSource">Value used to indicate threads created by this addin.</param>
-        /// <returns>List of all active discussion threads.</returns>
-        protected abstract IEnumerable<IPullRequestDiscussionThread> InternalFetchActiveDiscussionThreads(string commentSource);
+        /// <returns>List of all discussion threads.</returns>
+        protected abstract IEnumerable<IPullRequestDiscussionThread> InternalFetchDiscussionThreads(string commentSource);
 
         /// <summary>
         /// Returns a list of all files modified in a pull request.


### PR DESCRIPTION
Support different resolutions for comment thread resolving.

* If a comment thread for an issue is resolved as won't fix it won't be posted again
* If a comment thread for an issues is resolved as resolved and issue still exists it will be reopened

Fixes #29 
Fixes #30 
