### PR TITLE
(GH-134) Add setting to limit number of issues posted to a pull request across multiple runs

### DIFF
--- a/src/Cake.Issues.PullRequests.Tests/IssueFiltererTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/IssueFiltererTests.cs
@@ -472,6 +472,164 @@
                     }
                 }
 
+                public sealed class ForPropertyMaxIssuesToPostAcrossRuns
+                {
+                    [Fact]
+                    public void Should_Limit_Messages_To_Maximum()
+                    {
+                        // Given
+                        var fixture = new PullRequestsFixture();
+                        fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPostAcrossRuns = 2;
+
+                        var issue1 =
+                            IssueBuilder
+                                .NewIssue("Message Foo", "ProviderType Foo", "ProviderName Foo")
+                                .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 10)
+                                .OfRule("Rule Foo")
+                                .WithPriority(IssuePriority.Warning)
+                                .Create();
+                        var issue2 =
+                            IssueBuilder
+                                .NewIssue("Message Bar", "ProviderType Bar", "ProviderName Bar")
+                                .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 12)
+                                .OfRule("Rule Bar")
+                                .WithPriority(IssuePriority.Warning)
+                                .Create();
+
+                        // When
+                        var issues =
+                            fixture.FilterIssues(
+                                new List<IIssue>
+                                {
+                                issue1, issue2
+                                },
+                                new Dictionary<IIssue, IssueCommentInfo>(),
+                                new List<IPullRequestDiscussionThread>
+                                {
+                                new PullRequestDiscussionThread(
+                                    1,
+                                    PullRequestDiscussionStatus.Active,
+                                    @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                                    new List<IPullRequestDiscussionComment>
+                                    {
+                                        new PullRequestDiscussionComment
+                                        {
+                                            Content = "Message FooBar",
+                                            IsDeleted = false
+                                        }
+                                    })
+                                });
+
+                        // Then
+                        issues.Count().ShouldBe(1);
+                        issues.ShouldContain(issue1);
+                        fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 2 across all runs (1 issues already posted in previous runs)");
+                    }
+
+                    [Fact]
+                    public void Should_Limit_Messages_To_Maximum_By_Priority()
+                    {
+                        // Given
+                        var fixture = new PullRequestsFixture();
+                        fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPostAcrossRuns = 2;
+
+                        var issue1 =
+                            IssueBuilder
+                                .NewIssue("Message Foo", "ProviderType Foo", "ProviderName Foo")
+                                .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 10)
+                                .OfRule("Rule Foo")
+                                .WithPriority(IssuePriority.Warning)
+                                .Create();
+                        var issue2 =
+                            IssueBuilder
+                                .NewIssue("Message Bar", "ProviderType Bar", "ProviderName Bar")
+                                .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 12)
+                                .OfRule("Rule Bar")
+                                .WithPriority(IssuePriority.Error)
+                                .Create();
+
+                        // When
+                        var issues =
+                            fixture.FilterIssues(
+                                new List<IIssue>
+                                {
+                                issue1, issue2
+                                },
+                                new Dictionary<IIssue, IssueCommentInfo>(),
+                                new List<IPullRequestDiscussionThread>
+                                {
+                                new PullRequestDiscussionThread(
+                                    1,
+                                    PullRequestDiscussionStatus.Active,
+                                    @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                                    new List<IPullRequestDiscussionComment>
+                                    {
+                                        new PullRequestDiscussionComment
+                                        {
+                                            Content = "Message FooBar",
+                                            IsDeleted = false
+                                        }
+                                    })
+                                });
+
+                        // Then
+                        issues.Count().ShouldBe(1);
+                        issues.ShouldContain(issue2);
+                        fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 2 across all runs (1 issues already posted in previous runs)");
+                    }
+
+                    [Fact]
+                    public void Should_Limit_Messages_To_Maximum_By_FilePath()
+                    {
+                        // Given
+                        var fixture = new PullRequestsFixture();
+                        fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPostAcrossRuns = 2;
+
+                        var issue1 =
+                            IssueBuilder
+                                .NewIssue("Message Foo", "ProviderType Foo", "ProviderName Foo")
+                                .OfRule("Rule Foo")
+                                .WithPriority(IssuePriority.Warning)
+                                .Create();
+                        var issue2 =
+                            IssueBuilder
+                                .NewIssue("Message Bar", "ProviderType Bar", "ProviderName Bar")
+                                .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 12)
+                                .OfRule("Rule Bar")
+                                .WithPriority(IssuePriority.Warning)
+                                .Create();
+
+                        // When
+                        var issues =
+                            fixture.FilterIssues(
+                                new List<IIssue>
+                                {
+                                issue1, issue2
+                                },
+                                new Dictionary<IIssue, IssueCommentInfo>(),
+                                new List<IPullRequestDiscussionThread>
+                                {
+                                new PullRequestDiscussionThread(
+                                    1,
+                                    PullRequestDiscussionStatus.Active,
+                                    @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                                    new List<IPullRequestDiscussionComment>
+                                    {
+                                        new PullRequestDiscussionComment
+                                        {
+                                            Content = "Message FooBar",
+                                            IsDeleted = false
+                                        }
+                                    })
+                                });
+
+                        // Then
+                        issues.Count().ShouldBe(1);
+                        issues.ShouldContain(issue2);
+                        fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 2 across all runs (1 issues already posted in previous runs)");
+                    }
+                }
+
                 public sealed class ForPropertyMaxIssuesToPostForEachIssueProvider
                 {
                     [Fact]

--- a/src/Cake.Issues.PullRequests.Tests/PullRequestsFixture.cs
+++ b/src/Cake.Issues.PullRequests.Tests/PullRequestsFixture.cs
@@ -67,14 +67,32 @@
             IEnumerable<IIssue> issues,
             IDictionary<IIssue, IssueCommentInfo> issueComments)
         {
+            return
+                this
+                    .GetIssueFilterer()
+                    .FilterIssues(issues, issueComments, null);
+        }
+
+        public IEnumerable<IIssue> FilterIssues(
+            IEnumerable<IIssue> issues,
+            IDictionary<IIssue, IssueCommentInfo> issueComments,
+            IEnumerable<IPullRequestDiscussionThread> threadsWithoutIssues)
+        {
+            return
+                this
+                    .GetIssueFilterer()
+                    .FilterIssues(issues, issueComments, threadsWithoutIssues);
+        }
+
+        private IssueFilterer GetIssueFilterer()
+        {
             this.PullRequestSystem?.Initialize(this.ReportIssuesToPullRequestSettings);
 
-            var issueFilterer =
+            return
                 new IssueFilterer(
                     this.Log,
                     this.PullRequestSystem,
                     this.ReportIssuesToPullRequestSettings);
-            return issueFilterer.FilterIssues(issues, issueComments);
         }
     }
 }

--- a/src/Cake.Issues.PullRequests/IssueFilterer.cs
+++ b/src/Cake.Issues.PullRequests/IssueFilterer.cs
@@ -48,10 +48,13 @@
         /// <param name="issues">Found issues.</param>
         /// <param name="issueComments">List of existing comments on the pull request or null if the
         /// pull request system doesn't support discussions.</param>
+        /// <param name="threadsWithoutIssues">List of threads which were reported by Cake.Issues but
+        /// no longer have a matching issue in <paramref name="issues"/>.</param>
         /// <returns>List of filtered issues.</returns>
         public IEnumerable<IIssue> FilterIssues(
             IEnumerable<IIssue> issues,
-            IDictionary<IIssue, IssueCommentInfo> issueComments)
+            IDictionary<IIssue, IssueCommentInfo> issueComments,
+            IEnumerable<IPullRequestDiscussionThread> threadsWithoutIssues)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull(nameof(issues));
@@ -66,7 +69,7 @@
                 result = this.FilterPreExistingComments(result, issueComments);
             }
 
-            result = this.FilterIssuesByNumber(result);
+            result = this.FilterIssuesByNumber(result, threadsWithoutIssues);
 
             // Apply custom filters.
             foreach (var filterer in this.settings.IssueFilters)
@@ -207,8 +210,12 @@
         /// Limits the number of issues so as to not overload the pull request with too many comments.
         /// </summary>
         /// <param name="issues">List of issues which should be filtered.</param>
+        /// <param name="threadsWithoutIssues">List of threads which were reported by Cake.Issues but
+        /// no longer have a matching issue in <paramref name="issues"/>.</param>
         /// <returns>List of issues limited to the maximum number of issues to post.</returns>
-        private IList<IIssue> FilterIssuesByNumber(IList<IIssue> issues)
+        private IList<IIssue> FilterIssuesByNumber(
+            IList<IIssue> issues,
+            IEnumerable<IPullRequestDiscussionThread> threadsWithoutIssues)
         {
             if (!issues.Any())
             {
@@ -264,6 +271,29 @@
                     "{0} issue(s) were filtered to match the global issue limit of {1}",
                     issuesFilteredCount,
                     this.settings.MaxIssuesToPost);
+            }
+
+            // Apply global issue limit over multiple runs
+            if (this.settings.MaxIssuesToPostAcrossRuns.HasValue && threadsWithoutIssues != null)
+            {
+                var maxIssuesToPostInThisRun =
+                    this.settings.MaxIssuesToPostAcrossRuns.Value - threadsWithoutIssues.Count();
+                var countBefore = issues.Count;
+                result =
+                    result
+                        .OrderByDescending(x => x.Priority)
+                        .ThenBy(x => x.AffectedFileRelativePath is null)
+                        .ThenBy(x => x.AffectedFileRelativePath?.FullPath)
+                        .Take(maxIssuesToPostInThisRun)
+                        .ToList();
+                var issuesFilteredCount = countBefore - result.Count;
+                totalIssuesFilteredCount += issuesFilteredCount;
+
+                this.log.Information(
+                    "{0} issue(s) were filtered to match the global issue limit of {1} across all runs ({2} issues already posted in previous runs)",
+                    issuesFilteredCount,
+                    this.settings.MaxIssuesToPostAcrossRuns,
+                    threadsWithoutIssues.Count());
             }
 
             this.log.Verbose(

--- a/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestSettings.cs
+++ b/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestSettings.cs
@@ -32,9 +32,21 @@
         /// are prioritized.
         /// Set to <c>null</c> to not set a global limit.
         /// Default is to not set a global limit.
-        /// Use <see cref="MaxIssuesToPostForEachIssueProvider"/> to set the limit for each issue provider.
+        /// Use <see cref="MaxIssuesToPostForEachIssueProvider"/> to set the limit for each issue provider
+        /// and <see cref="MaxIssuesToPostAcrossRuns"/> to set a limit across multiple runs.
         /// </summary>
         public int? MaxIssuesToPost { get; set; }
+
+        /// <summary>
+        /// Gets or sets the global number of issues which should be posted at maximum over all
+        /// <see cref="IIssueProvider"/> and across multiple runs.
+        /// Issues are filtered by <see cref="IIssue.Priority"/> and issues with an <see cref="IIssue.AffectedFileRelativePath"/>
+        /// are prioritized.
+        /// Set to <c>null</c> to not set a limit across multiple runs.
+        /// Default is to not set a limit across multiple runs.
+        /// Use <see cref="MaxIssuesToPost"/> to set a limit for a single run.
+        /// </summary>
+        public int? MaxIssuesToPostAcrossRuns { get; set; }
 
         /// <summary>
         /// Gets or sets the number of issues which should be posted at maximum for each


### PR DESCRIPTION
Add additional settings which allow to limit the number of issues posted to a pull request across multiple runs.

It adds a new setting `ReportIssuesToPullRequestSettings.MaxIssuesToPostAcrossRuns` which is applied after `ReportIssuesToPullRequestSettings.MaxIssuesToPostForEachIssueProvider` and `ReportIssuesToPullRequestSettings.MaxIssuesToPost`.

Behavior is like this. Assuming you have the following issues:
- 70 issues of provider A
- 70 issues of provider B

And the following settings:
- MaxIssuesToPostForEachIssueProvider: 20
- MaxIssuesToPost: 30
- MaxIssuesToPostAcrossRuns: 55

The following will happen:
- First run: 30 issues are posted but not more than 20 of either provider A or B
- If you fix the issues and run again: 25 issues are posted but not more than 20 of either provider A or B
- If you fix the issues and run again: The remaining 85 won't be posted in this pull request

Fixes #134 