### PR TITLE
Consider unresolved issues for MaxIssuesToPostAcrossRuns

### DIFF
--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -733,7 +733,7 @@ namespace Cake.Issues.PullRequests.Tests
         public sealed class TheRunMethodWithDiscussionThreadsCapability
         {
             [Fact]
-            public void Should_Limit_Messages_To_Maximum_Across_Runs_Does_Exceed_The_Number()
+            public void Should_Limit_Messages_To_Maximum_Across_Runs_Nothing_New_To_Post()
             {
                 // Given
                 var issue1 =
@@ -772,26 +772,21 @@ namespace Cake.Issues.PullRequests.Tests
                                         {
                                             new PullRequestDiscussionComment
                                             {
-                                                Content = "Message FooBar",
+                                                Content = "Message Foo",
                                                 IsDeleted = false
                                             }
                                         }),
                                     new PullRequestDiscussionThread(
-                                        1,
+                                        2,
                                         PullRequestDiscussionStatus.Active,
                                         @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
                                         new List<IPullRequestDiscussionComment>
                                         {
                                             new PullRequestDiscussionComment
                                             {
-                                                Content = "Message FooBar",
+                                                Content = "Message Bar",
                                                 IsDeleted = false
                                             },
-                                            new PullRequestDiscussionComment
-                                            {
-                                                Content = "Message BarFoo",
-                                                IsDeleted = false
-                                            }
                                         })
                                 }));
 
@@ -812,9 +807,8 @@ namespace Cake.Issues.PullRequests.Tests
                 // Then
                 result.ReportedIssues.Count().ShouldBe(3);
                 result.PostedIssues.Count().ShouldBe(0);
-                result.PostedIssues.ShouldContain(issue1);
-                fixture.Log.Entries.ShouldContain(x => x.Message == "0 issue(s) were filtered to match the global issue limit of 2 across all runs (2 issues already posted in previous runs)");
-                fixture.Log.Entries.ShouldContain(x => x.Message.StartsWith("Posting 0 issue(s):"));
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 2 across all runs (2 issues already posted in previous runs)");
+                fixture.Log.Entries.ShouldContain(x => x.Message == "All issues were filtered. Nothing new to post.");
             }
 
             [Fact]

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -818,6 +818,67 @@ namespace Cake.Issues.PullRequests.Tests
             }
 
             [Fact]
+            public void Should_Limit_Messages_To_Maximum_Across_Runs()
+            {
+                // Given
+                var issue1 =
+                    IssueBuilder
+                        .NewIssue("Message Foo", "ProviderType Foo", "ProviderName Foo")
+                        .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 10)
+                        .OfRule("Rule Foo")
+                        .WithPriority(IssuePriority.Warning)
+                        .Create();
+                var issue2 =
+                    IssueBuilder
+                        .NewIssue("Message Bar", "ProviderType Bar", "ProviderName Bar")
+                        .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 12)
+                        .OfRule("Rule Bar")
+                        .WithPriority(IssuePriority.Warning)
+                        .Create();
+
+                var fixture =
+                    new PullRequestsFixture(
+                        (builder, settings) => builder
+                            .WithDiscussionThreadsCapability(
+                                new List<IPullRequestDiscussionThread>
+                                {
+                                    new PullRequestDiscussionThread(
+                                        1,
+                                        PullRequestDiscussionStatus.Active,
+                                        @"src\Cake.Issues.Tests\FakeIssueProvider.cs",
+                                        new List<IPullRequestDiscussionComment>
+                                        {
+                                            new PullRequestDiscussionComment
+                                            {
+                                                Content = "Message FooBar",
+                                                IsDeleted = false
+                                            }
+                                        })
+                                }));
+
+                fixture.IssueProviders.Clear();
+                fixture.IssueProviders.Add(
+                    new FakeIssueProvider(
+                        fixture.Log,
+                        new List<IIssue>
+                        {
+                            issue1, issue2
+                        }));
+
+                fixture.ReportIssuesToPullRequestSettings.MaxIssuesToPostAcrossRuns = 2;
+
+                // When
+                var result = fixture.RunOrchestratorForIssueProviders();
+
+                // Then
+                result.ReportedIssues.Count().ShouldBe(2);
+                result.PostedIssues.Count().ShouldBe(1);
+                result.PostedIssues.ShouldContain(issue1);
+                fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 2 across all runs (1 issues already posted in previous runs)");
+                fixture.Log.Entries.ShouldContain(x => x.Message.StartsWith("Posting 1 issue(s):"));
+            }
+
+            [Fact]
             public void Should_Limit_Messages_To_Maximum_Across_Runs_By_Priority()
             {
                 // Given

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -807,6 +807,7 @@ namespace Cake.Issues.PullRequests.Tests
                 // Then
                 result.ReportedIssues.Count().ShouldBe(3);
                 result.PostedIssues.Count().ShouldBe(0);
+                fixture.Log.Entries.ShouldContain(x => x.Message == "2 issue(s) were filtered because they were already present");
                 fixture.Log.Entries.ShouldContain(x => x.Message == "1 issue(s) were filtered to match the global issue limit of 2 across all runs (2 issues already posted in previous runs)");
                 fixture.Log.Entries.ShouldContain(x => x.Message == "All issues were filtered. Nothing new to post.");
             }

--- a/src/Cake.Issues.PullRequests.Tests/PullRequestsFixture.cs
+++ b/src/Cake.Issues.PullRequests.Tests/PullRequestsFixture.cs
@@ -1,4 +1,4 @@
-﻿namespace Cake.Issues.PullRequests.Tests
+namespace Cake.Issues.PullRequests.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -76,12 +76,12 @@
         public IEnumerable<IIssue> FilterIssues(
             IEnumerable<IIssue> issues,
             IDictionary<IIssue, IssueCommentInfo> issueComments,
-            IEnumerable<IPullRequestDiscussionThread> threadsWithoutIssues)
+            IReadOnlyCollection<IPullRequestDiscussionThread> existingThreads)
         {
             return
                 this
                     .GetIssueFilterer()
-                    .FilterIssues(issues, issueComments, threadsWithoutIssues);
+                    .FilterIssues(issues, issueComments, existingThreads);
         }
 
         private IssueFilterer GetIssueFilterer()

--- a/src/Cake.Issues.PullRequests/IssueFilterer.cs
+++ b/src/Cake.Issues.PullRequests/IssueFilterer.cs
@@ -274,10 +274,8 @@ namespace Cake.Issues.PullRequests
             // Apply global issue limit over multiple runs
             if (this.settings.MaxIssuesToPostAcrossRuns.HasValue && existingThreads != null)
             {
-                var existingCommentsCount = existingThreads.SelectMany(p => p.Comments).Count();
-
                 var maxIssuesToPostInThisRun =
-                    this.settings.MaxIssuesToPostAcrossRuns.Value - existingCommentsCount;
+                    this.settings.MaxIssuesToPostAcrossRuns.Value - existingThreads.Count;
                 var countBefore = issues.Count;
                 result =
                     result
@@ -293,7 +291,7 @@ namespace Cake.Issues.PullRequests
                     "{0} issue(s) were filtered to match the global issue limit of {1} across all runs ({2} issues already posted in previous runs)",
                     issuesFilteredCount,
                     this.settings.MaxIssuesToPostAcrossRuns,
-                    existingCommentsCount);
+                    existingThreads.Count);
             }
 
             this.log.Verbose(

--- a/src/Cake.Issues.PullRequests/IssueFilterer.cs
+++ b/src/Cake.Issues.PullRequests/IssueFilterer.cs
@@ -1,4 +1,4 @@
-﻿namespace Cake.Issues.PullRequests
+namespace Cake.Issues.PullRequests
 {
     using System;
     using System.Collections.Generic;
@@ -48,13 +48,12 @@
         /// <param name="issues">Found issues.</param>
         /// <param name="issueComments">List of existing comments on the pull request or null if the
         /// pull request system doesn't support discussions.</param>
-        /// <param name="threadsWithoutIssues">List of threads which were reported by Cake.Issues but
-        /// no longer have a matching issue in <paramref name="issues"/>.</param>
+        /// <param name="existingThreads">List of threads which were reported by Cake.Issues</param>
         /// <returns>List of filtered issues.</returns>
         public IEnumerable<IIssue> FilterIssues(
             IEnumerable<IIssue> issues,
             IDictionary<IIssue, IssueCommentInfo> issueComments,
-            IEnumerable<IPullRequestDiscussionThread> threadsWithoutIssues)
+            IReadOnlyCollection<IPullRequestDiscussionThread> existingThreads)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull(nameof(issues));
@@ -69,7 +68,7 @@
                 result = this.FilterPreExistingComments(result, issueComments);
             }
 
-            result = this.FilterIssuesByNumber(result, threadsWithoutIssues);
+            result = this.FilterIssuesByNumber(result, existingThreads);
 
             // Apply custom filters.
             foreach (var filterer in this.settings.IssueFilters)
@@ -210,12 +209,11 @@
         /// Limits the number of issues so as to not overload the pull request with too many comments.
         /// </summary>
         /// <param name="issues">List of issues which should be filtered.</param>
-        /// <param name="threadsWithoutIssues">List of threads which were reported by Cake.Issues but
-        /// no longer have a matching issue in <paramref name="issues"/>.</param>
+        /// <param name="existingThreads">List of threads which were reported by Cake.Issues.</param>
         /// <returns>List of issues limited to the maximum number of issues to post.</returns>
         private IList<IIssue> FilterIssuesByNumber(
             IList<IIssue> issues,
-            IEnumerable<IPullRequestDiscussionThread> threadsWithoutIssues)
+            IReadOnlyCollection<IPullRequestDiscussionThread> existingThreads)
         {
             if (!issues.Any())
             {
@@ -274,10 +272,12 @@
             }
 
             // Apply global issue limit over multiple runs
-            if (this.settings.MaxIssuesToPostAcrossRuns.HasValue && threadsWithoutIssues != null)
+            if (this.settings.MaxIssuesToPostAcrossRuns.HasValue && existingThreads != null)
             {
+                var existingCommentsCount = existingThreads.SelectMany(p => p.Comments).Count();
+
                 var maxIssuesToPostInThisRun =
-                    this.settings.MaxIssuesToPostAcrossRuns.Value - threadsWithoutIssues.Count();
+                    this.settings.MaxIssuesToPostAcrossRuns.Value - existingCommentsCount;
                 var countBefore = issues.Count;
                 result =
                     result
@@ -293,7 +293,7 @@
                     "{0} issue(s) were filtered to match the global issue limit of {1} across all runs ({2} issues already posted in previous runs)",
                     issuesFilteredCount,
                     this.settings.MaxIssuesToPostAcrossRuns,
-                    threadsWithoutIssues.Count());
+                    existingCommentsCount);
             }
 
             this.log.Verbose(


### PR DESCRIPTION
The logic was wrong. It counted every thread that does not have any issues or just outdated ones.
It should not count threads.
It should count all existing comments across every thread and use that number to bottleneck it.

As far as I can see, the existant test just got lucky with the numbers.