### PR TITLE
(GH-143)  Use `IIssue.Identifier` to identify comment threads

### DIFF
--- a/src/Cake.Issues.PullRequests.Tests/BaseDiscussionThreadsCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/BaseDiscussionThreadsCapabilityTests.cs
@@ -120,6 +120,7 @@
                                 }
                             })
                         {
+                            CommentIdentifier = "Message Foo",
                             CommentSource = settings.CommentSource,
                         }
                     };
@@ -163,34 +164,36 @@
                 var settings = new ReportIssuesToPullRequestSettings(@"c:\repo");
                 var discussionThread1 =
                     new PullRequestDiscussionThread(
-                            1,
-                            PullRequestDiscussionStatus.Active,
-                            new FilePath(@"src\Cake.Issues.Tests\Foo.cs"),
-                            new List<IPullRequestDiscussionComment>
+                        1,
+                        PullRequestDiscussionStatus.Active,
+                        new FilePath(@"src\Cake.Issues.Tests\Foo.cs"),
+                        new List<IPullRequestDiscussionComment>
+                        {
+                            new PullRequestDiscussionComment()
                             {
-                                new PullRequestDiscussionComment()
-                                {
-                                    Content = "Message Foo",
-                                    IsDeleted = false
-                                }
-                            })
+                                Content = "Message Foo",
+                                IsDeleted = false
+                            }
+                        })
                     {
+                        CommentIdentifier = "Message Foo",
                         CommentSource = settings.CommentSource,
                     };
                 var discussionThread2 =
                     new PullRequestDiscussionThread(
-                            1,
-                            PullRequestDiscussionStatus.Active,
-                            new FilePath(@"src\Cake.Issues.Tests\Bar.cs"),
-                            new List<IPullRequestDiscussionComment>
+                        1,
+                        PullRequestDiscussionStatus.Active,
+                        new FilePath(@"src\Cake.Issues.Tests\Bar.cs"),
+                        new List<IPullRequestDiscussionComment>
+                        {
+                            new PullRequestDiscussionComment()
                             {
-                                new PullRequestDiscussionComment()
-                                {
-                                    Content = "Message Bar",
-                                    IsDeleted = false
-                                }
-                            })
+                                Content = "Message Bar",
+                                IsDeleted = false
+                            }
+                        })
                     {
+                        CommentIdentifier = "Message Bar",
                         CommentSource = settings.CommentSource,
                     };
                 var discussionThreads =
@@ -242,18 +245,19 @@
                 var settings = new ReportIssuesToPullRequestSettings(@"c:\repo");
                 var discussionThread1 =
                     new PullRequestDiscussionThread(
-                            1,
-                            PullRequestDiscussionStatus.Active,
-                            new FilePath(@"src\Cake.Issues.Tests\Foo.cs"),
-                            new List<IPullRequestDiscussionComment>
+                        1,
+                        PullRequestDiscussionStatus.Active,
+                        new FilePath(@"src\Cake.Issues.Tests\Foo.cs"),
+                        new List<IPullRequestDiscussionComment>
+                        {
+                            new PullRequestDiscussionComment()
                             {
-                                new PullRequestDiscussionComment()
-                                {
-                                    Content = "Message Foo",
-                                    IsDeleted = false
-                                }
-                            })
+                                Content = "Message Foo",
+                                IsDeleted = false
+                            }
+                        })
                     {
+                        CommentIdentifier = "Message Foo",
                         CommentSource = settings.CommentSource,
                     };
                 var discussionThread2 =

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -917,7 +917,10 @@ namespace Cake.Issues.PullRequests.Tests
                                                 Content = "Message Foo",
                                                 IsDeleted = false
                                             }
-                                        }),
+                                        })
+                                    {
+                                        CommentIdentifier = "Message Foo"
+                                    },
                                     new PullRequestDiscussionThread(
                                         2,
                                         PullRequestDiscussionStatus.Active,
@@ -930,6 +933,9 @@ namespace Cake.Issues.PullRequests.Tests
                                                 IsDeleted = false
                                             },
                                         })
+                                    {
+                                        CommentIdentifier = "Message Bar"
+                                    }
                                 }));
 
                 fixture.IssueProviders.Clear();
@@ -1121,6 +1127,7 @@ namespace Cake.Issues.PullRequests.Tests
                                             }
                                         })
                                     {
+                                        CommentIdentifier = "Message Foo",
                                         CommentSource = settings.CommentSource,
                                     }
                                 }));
@@ -1191,6 +1198,7 @@ namespace Cake.Issues.PullRequests.Tests
                                             }
                                         })
                                     {
+                                        CommentIdentifier = "Message Foo",
                                         CommentSource = settings.CommentSource,
                                         Resolution = PullRequestDiscussionResolution.WontFix
                                     }
@@ -1260,6 +1268,7 @@ namespace Cake.Issues.PullRequests.Tests
                                             }
                                         })
                                     {
+                                        CommentIdentifier = "Message Foo",
                                         CommentSource = settings.CommentSource,
                                     }
                                 }));
@@ -1324,6 +1333,7 @@ namespace Cake.Issues.PullRequests.Tests
                                             }
                                         })
                                     {
+                                        CommentIdentifier = "Foo",
                                         CommentSource = "DifferentCommentSource",
                                     }
                                 }));
@@ -1378,6 +1388,7 @@ namespace Cake.Issues.PullRequests.Tests
                                             }
                                         })
                                     {
+                                        CommentIdentifier = "Bar",
                                         CommentSource = settings.CommentSource
                                     }
                                 }));
@@ -1430,6 +1441,7 @@ namespace Cake.Issues.PullRequests.Tests
                                             }
                                         })
                                     {
+                                        CommentIdentifier = "Bar",
                                         CommentSource = "DifferentCommentSource"
                                     }
                                 }));
@@ -1481,6 +1493,7 @@ namespace Cake.Issues.PullRequests.Tests
                                             }
                                         })
                                     {
+                                        CommentIdentifier = "Message Foo",
                                         CommentSource = settings.CommentSource,
                                         Resolution = PullRequestDiscussionResolution.Resolved
                                     }
@@ -1534,6 +1547,7 @@ namespace Cake.Issues.PullRequests.Tests
                                             }
                                         })
                                     {
+                                        CommentIdentifier = "Message Foo",
                                         CommentSource = "DifferentCommentSource",
                                         Resolution = PullRequestDiscussionResolution.Resolved
                                     }
@@ -1617,6 +1631,9 @@ namespace Cake.Issues.PullRequests.Tests
                                                 IsDeleted = false
                                             }
                                         })
+                                    {
+                                        CommentIdentifier = "Message Foo"
+                                    }
                                 }));
 
                 var threadToReopen =

--- a/src/Cake.Issues.PullRequests/IPullRequestDiscussionThread.cs
+++ b/src/Cake.Issues.PullRequests/IPullRequestDiscussionThread.cs
@@ -36,6 +36,11 @@
         string CommentSource { get; set; }
 
         /// <summary>
+        /// Gets or sets the value to identify the comment across multiple runs.
+        /// </summary>
+        string CommentIdentifier { get; set; }
+
+        /// <summary>
         /// Gets all the comments of this thread.
         /// </summary>
         IList<IPullRequestDiscussionComment> Comments { get; }

--- a/src/Cake.Issues.PullRequests/Orchestrator.cs
+++ b/src/Cake.Issues.PullRequests/Orchestrator.cs
@@ -279,7 +279,7 @@ namespace Cake.Issues.PullRequests
         /// * The thread is active.
         /// * The thread is for the same file.
         /// * The thread was created by the same logic, i.e. the same <see cref="IPullRequestDiscussionThread.CommentSource"/>.
-        /// * The comment contains the same content.
+        /// * The thread was created for the same issue, i.e. the same <see cref="IPullRequestDiscussionThread.CommentIdentifier"/>.
         /// </summary>
         /// <remarks>
         /// The line cannot be used since comments can move around.
@@ -296,10 +296,10 @@ namespace Cake.Issues.PullRequests
             issue.NotNull(nameof(issue));
             existingThreads.NotNull(nameof(existingThreads));
 
-            // Select threads that point to the same file and have been marked with the given comment source.
+            // Select threads that point to the same file and issue identifier.
             var matchingThreads =
                 existingThreads
-                    .Where(x => FilePathsAreMatching(issue, x))
+                    .Where(x => FilePathsAreMatching(issue, x) && x.CommentIdentifier == issue.Identifier)
                     .ToList();
 
             if (matchingThreads.Any())
@@ -321,8 +321,7 @@ namespace Cake.Issues.PullRequests
                     (from comment in thread.Comments
                     where
                         comment != null &&
-                        !comment.IsDeleted &&
-                        comment.Content == issue.MessageText
+                        !comment.IsDeleted
                     select
                         comment).ToList();
 

--- a/src/Cake.Issues.PullRequests/PullRequestDiscussionThread.cs
+++ b/src/Cake.Issues.PullRequests/PullRequestDiscussionThread.cs
@@ -64,5 +64,8 @@
 
         /// <inheritdoc/>
         public string CommentSource { get; set; }
+
+        /// <inheritdoc/>
+        public string CommentIdentifier { get; set; }
     }
 }


### PR DESCRIPTION
Use `IIssue.Identifier` to identify comment threads across multiple runs.

Fixes #143 